### PR TITLE
Work done as part of Google Summer of Code 2018

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,7 @@ gcp_CPPFLAGS += $(JSONGLIB_CFLAGS)
 gcp_CPPFLAGS += $(GOA_CFLAGS)
 
 gcp_LDADD  =  $(CPDBBACKEND_LIBS)
-gcp_LDADD += -lcups -lpthread -lm -lcrypt
+gcp_LDADD += -lpthread -lm -lcrypt
 gcp_LDADD += $(GLIB_LIBS)
 gcp_LDADD += $(GIO_LIBS)
 gcp_LDADD += $(GIOUNIX_LIBS)

--- a/src/gcp_server.c
+++ b/src/gcp_server.c
@@ -206,6 +206,7 @@ on_handle_print_file (PrintBackend *skeleton,
                       const gchar *file_path_name,
                       gint num_settings,
                       GVariant *settings,
+                      const gchar *final_file_path,
                       gpointer user_data)
 {
   g_print ("on_handle_print_file() called\n");

--- a/src/gcp_server.h
+++ b/src/gcp_server.h
@@ -97,6 +97,7 @@ on_handle_print_file (PrintBackend *skeleton,
                       const gchar *file_path_name,
                       gint num_settings,
                       GVariant *settings,
+                      const gchar *final_file_path,
                       gpointer user_data);
 
 gint


### PR DESCRIPTION
Commits:

- **Removed unnecessary cups library**: Cups library isn't required for compiling this backend.

- **Add final_file_path to backend interface**: Fix the on_handle_print_file function due to change in the [Dbus Backend Interface](https://github.com/ayush268/cpdb-libs/commit/b90c188545dc0e98e5ff3aef988c51ec1390ca03).